### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,15 +102,15 @@ test:
 test-cov:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover.sh -r ./cmd/... ./pkg/...
 
-.PHONY: test-clean
-test-clean:
+.PHONY: test-cov-clean
+test-cov-clean:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover-clean.sh
 
 .PHONY: verify
 verify: check format test
 
 .PHONY: verify-extended
-verify-extended: install-requirements check-generate check format test test-clean
+verify-extended: install-requirements check-generate check format test-cov test-cov-clean
 
 .PHONY: start
 start:


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the test-cov target instead of the test target in the verify-extendet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
