### PR TITLE
update test suite to be a shoot test suite

### DIFF
--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -6,7 +6,7 @@ spec:
   description: gvisor extension test suite that includes all serial beta tests
 
   activeDeadlineSeconds: 1800
-  labels: ["gardener", "beta"]
+  labels: ["shoot", "beta"]
   behavior:
   - serial
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the current testdefinition from a gardener to a shoot testdefinition as it actually requires a shoot.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
