### PR TITLE
Fix containerd config file version detection

### DIFF
--- a/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
@@ -44,15 +44,20 @@ data:
     FILENAME=/var/host/etc/containerd/config.toml
     if ! grep -q containerd.runtimes.runsc "$FILENAME"; then
       echo "Configuring containerd config file for gVisor."
-      VERSION="$(head -n 1 $FILENAME)"
 
-      if [ "$VERSION" == "version = 2" ]
+      # version 1 is the default version, even though it is deprecated, ref: https://containerd.io/releases/#daemon-configuration
+      # so use version 2 syntax only if it is explicitly enabled in the config file
+      if grep -q '^version.*=.*2$' "$FILENAME"
       then
-        echo "[plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runsc]
-          runtime_type = \"io.containerd.runsc.v1\"" >> /var/host/etc/containerd/config.toml
+        cat <<EOF >> $FILENAME
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+      runtime_type = "io.containerd.runsc.v1"
+    EOF
       else
-        echo "[plugins.cri.containerd.runtimes.runsc]
-          runtime_type = \"io.containerd.runsc.v1\"" >> /var/host/etc/containerd/config.toml
+        cat <<EOF >> $FILENAME
+    [plugins.cri.containerd.runtimes.runsc]
+      runtime_type = "io.containerd.runsc.v1"
+    EOF
       fi
 
       echo "Restarting containerd"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix containerd config file version detection.

More info about the configuration file versions can be found at https://containerd.io/releases/#daemon-configuration

**Which issue(s) this PR fixes**:
Fixes #20 

**Special notes for your reviewer**:
Opened as draft till #18 is reviewed, approved and merged.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug in the gVisor installation script, that does not properly detect the containerd configuration file version, is now fixed.
```
