### PR TITLE
Update runsc and shim binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ ENTRYPOINT ["/gardener-extension-runtime-gvisor"]
 ############# gardener-extension-runtime-gvisor-installation for the installation daemonSet
 FROM alpine:3.13.5 AS gardener-extension-runtime-gvisor-installation
 
-COPY --from=builder /usr/local/bin/containerd-shim-runsc-v1.linux-amd64 /var/content/containerd-shim-runsc-v1.linux-amd64
+COPY --from=builder /usr/local/bin/containerd-shim-runsc-v1 /var/content/containerd-shim-runsc-v1
 COPY --from=builder /usr/local/bin/runsc /var/content/runsc

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,7 @@ LD_FLAGS                    := $(shell ./vendor/github.com/gardener/gardener/hac
 IGNORE_OPERATION_ANNOTATION := true
 
 ### GVisor version: https://github.com/google/gvisor/releases
-RUNSC_VERSION				 	:= 20200219.0
-
-### GVisor containerd shim version: https://github.com/google/gvisor-containerd-shim/releases
-CONTAINERD_RUNSC_SHIM_VERSION 	:= v0.0.4
+GVISOR_VERSION				 	:= 20210726
 
 #################################################################
 # Rules related to binary build, Docker image build and release #
@@ -41,7 +38,7 @@ install:
 
 .PHONY: install-binaries
 install-binaries:
-	@bash $(HACK_DIR)/install-binaries.sh $(RUNSC_VERSION) $(CONTAINERD_RUNSC_SHIM_VERSION)
+	@bash $(HACK_DIR)/install-binaries.sh $(GVISOR_VERSION)
 
 .PHONY: docker-login
 docker-login:

--- a/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
@@ -35,7 +35,7 @@ data:
     else
       echo "Updating shim binary."
       chmod +x containerd-shim-runsc-v1
-      # shim is a long running process. Will only use new shim, wenn old shim stopped.
+      # shim is a long running process. Will only use new shim, when old shim stopped.
       # killing the shim is not an option, as it kills its containers
       mv containerd-shim-runsc-v1 "$TARGET_SHIM"
     fi

--- a/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
@@ -28,16 +28,16 @@ data:
     TARGET_SHIM="/var/host/$BIN_TARGET_DIR/containerd-shim-runsc-v1"
     if [ ! -f "$TARGET_SHIM" ]; then
       echo "Adding shim binary."
-      chmod +x containerd-shim-runsc-v1.linux-amd64
-      mv containerd-shim-runsc-v1.linux-amd64 "$TARGET_SHIM"
-    elif diff containerd-shim-runsc-v1.linux-amd64 "$TARGET_SHIM"  > /dev/null; then
+      chmod +x containerd-shim-runsc-v1
+      mv containerd-shim-runsc-v1 "$TARGET_SHIM"
+    elif diff containerd-shim-runsc-v1 "$TARGET_SHIM"  > /dev/null; then
       echo "Shim binary up to date."
     else
       echo "Updating shim binary."
-      chmod +x containerd-shim-runsc-v1.linux-amd64
+      chmod +x containerd-shim-runsc-v1
       # shim is a long running process. Will only use new shim, wenn old shim stopped.
       # killing the shim is not an option, as it kills its containers
-      mv containerd-shim-runsc-v1.linux-amd64 "$TARGET_SHIM"
+      mv containerd-shim-runsc-v1 "$TARGET_SHIM"
     fi
 
     # configuring containerd config file for gVisor

--- a/hack/install-binaries.sh
+++ b/hack/install-binaries.sh
@@ -16,20 +16,15 @@
 
 set -e
 
-RUNSC_VERSION=$1
-CONTAINERD_RUNSC_SHIM_VERSION=$2
+GVISOR_VERSION=$1
 
-# Install runsc (gvisor)
-URL=https://storage.googleapis.com/gvisor/releases/release/$RUNSC_VERSION
-wget ${URL}/runsc
-wget ${URL}/runsc.sha512
-sha512sum -c runsc.sha512
-rm -f runsc.sha512
-mv runsc /usr/local/bin
-chmod 0755 /usr/local/bin/runsc
-
-# Install runsc containerd shim
-URL=https://github.com/google/gvisor-containerd-shim/releases/download/$CONTAINERD_RUNSC_SHIM_VERSION
-wget ${URL}/containerd-shim-runsc-v1.linux-amd64
-mv containerd-shim-runsc-v1.linux-amd64 /usr/local/bin
-chmod 0755 /usr/local/bin/containerd-shim-runsc-v1.linux-amd64
+# Install runsc (gVisor) and containerd-shim-runsc-v1 (shim for gVisor)
+ARCH=$(uname -m)
+URL=https://storage.googleapis.com/gvisor/releases/release/${GVISOR_VERSION}/${ARCH}
+wget ${URL}/runsc ${URL}/runsc.sha512 \
+    ${URL}/containerd-shim-runsc-v1 ${URL}/containerd-shim-runsc-v1.sha512
+sha512sum -c runsc.sha512 \
+    -c containerd-shim-runsc-v1.sha512
+rm -f *.sha512
+chmod a+rx runsc containerd-shim-runsc-v1
+mv runsc containerd-shim-runsc-v1 /usr/local/bin


### PR DESCRIPTION
**What this PR does / why we need it**:
Update runsc and shim binaries to version `20210726`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to #12 but to more recent version.
Opened as draft till #18 is reviewed, approved and merged.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `runsc` and `containerd-shim-runsc-v1` binaries are now updated to verison `20210726`.
```
