### PR TITLE
Disable cache for secrets

### DIFF
--- a/cmd/gardener-extension-runtime-gvisor/app/app.go
+++ b/cmd/gardener-extension-runtime-gvisor/app/app.go
@@ -26,7 +26,9 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -75,7 +77,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				controllercmd.LogErrAndExit(err, "Error completing options")
 			}
 
-			mgr, err := manager.New(restOpts.Completed().Config, mgrOpts.Completed().Options())
+			completedMgrOpts := mgrOpts.Completed().Options()
+			completedMgrOpts.ClientDisableCacheFor = []client.Object{
+				&corev1.Secret{}, // applied for ManagedResources
+			}
+
+			mgr, err := manager.New(restOpts.Completed().Config, completedMgrOpts)
 			if err != nil {
 				controllercmd.LogErrAndExit(err, "Could not instantiate manager")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable cache for secrets


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-networking-calico/pull/55

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The cache for Secrets has been disabled to decrease the extension controller's memory footprint.
```
