### PR TITLE
Prevent Docker Hub rate limits in the integration test

### DIFF
--- a/test/integration/container-runtime/container_runtime.go
+++ b/test/integration/container-runtime/container_runtime.go
@@ -239,7 +239,7 @@ func deployGVisorPod(ctx context.Context, c client.Client) (*corev1.Pod, error) 
 			Containers: []corev1.Container{
 				{
 					Name:  "gvisor-container",
-					Image: "busybox",
+					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.2",
 					Command: []string{
 						"sleep",
 						"10000000",


### PR DESCRIPTION
/area testing
/kind enhancement

Similar to https://github.com/gardener/gardener/issues/4160, currently the integration test can fail/flake because of Docker Hub rate limits

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
