### PR TITLE
Honor --max-concurrent-reconciles flag

### DIFF
--- a/cmd/gardener-extension-runtime-gvisor/app/app.go
+++ b/cmd/gardener-extension-runtime-gvisor/app/app.go
@@ -88,6 +88,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			reconcileOpts.Completed().Apply(&gvisorcontroller.DefaultAddOptions.IgnoreOperationAnnotation)
+			gvisorCtrlOpts.Completed().Apply(&gvisorcontroller.DefaultAddOptions.Controller)
 
 			if err := gvisorcontroller.AddToManager(mgr); err != nil {
 				controllercmd.LogErrAndExit(err, "Could not add controllers to manager")


### PR DESCRIPTION
/area quality
/kind bug

Ref https://github.com/gardener/gardener-extension-networking-calico/pull/42

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix operator
An issue causing runtime-gvisor extension controller to not respect the `--max-concurrent-reconciles` flag is now fixed.
```
