### PR TITLE
Fix a bug in the build machinery that was not properly setting the binary version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack
 VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
-LD_FLAGS                    := $(shell ./vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh github.com/gardener/"$(EXTENSION_PREFIX)-$(NAME)" "$(REPO_ROOT)/VERSION")
+LD_FLAGS                    := $(shell ./vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh github.com/gardener/"$(EXTENSION_PREFIX)-$(NAME)/pkg" "$(REPO_ROOT)/VERSION")
 IGNORE_OPERATION_ANNOTATION := true
 
 ### GVisor version: https://github.com/google/gvisor/releases


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #34 (Installation image is using wrong tag by default)

**Special notes for your reviewer**:
Incorrect path was being passed in LD_FILES - a "pkg" element was missing in the path. That resulted in version info not getting applied during build and retaining the hardcoded default - a 0.0.0 version. That default did not correspond to a valid gVisor image version.

**Release note**:
NONE