### PR TITLE
[pipeline] Inject effective version

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,7 @@ gardener-extension-runtime-gvisor:
     traits:
       version:
         preprocess: 'inject-commit-hash'
+        inject_effective_version: true
       publish:
         dockerimages:
           gardener-extension-runtime-gvisor:


### PR DESCRIPTION
**What this PR does / why we need it**:
[pipeline] Inject effective version

A follow-up on #35 because, even with that fix, the installed image is still not the expected one. 
When I started the controller version [v0.5.0-dev-5d1f3a4a3f0a6642d1f93c97075afa6f9224b6cc](https://github.com/gardener/gardener-extension-runtime-gvisor/tree/5d1f3a4a3f0a6642d1f93c97075afa6f9224b6cc), I was expecting the installation image to use the tag `v0.5.0-dev-5d1f3a4a3f0a6642d1f93c97075afa6f9224b6cc`, however it is using `v0.5.0-dev`, i.e. the effective version is not used during the build in the pipeline.

```bash
$ kubectl -n kube-system get pod -l app.kubernetes.io/name=containerd-gvisor -o json | jq .items[].spec.containers[].image
"eu.gcr.io/gardener-project/gardener/extensions/runtime-gvisor-installation:v0.5.0-dev"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
