### PR TITLE
Added support for a "version" subcommand

### DIFF
--- a/cmd/gardener-extension-runtime-gvisor/app/app.go
+++ b/cmd/gardener-extension-runtime-gvisor/app/app.go
@@ -17,6 +17,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener-extension-runtime-gvisor/pkg/version"
 	"os"
 
 	gvisorcontroller "github.com/gardener/gardener-extension-runtime-gvisor/pkg/controller"
@@ -105,6 +106,16 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 		},
 	}
+
+	// Add version subcommand
+	cmd.AddCommand(
+		&cobra.Command{
+			Use:   "version",
+			Short: "Print the program version number",
+			Run: func(cmd *cobra.Command, args []string) {
+				fmt.Print(version.Get().GitVersion)
+			},
+		})
 
 	aggOption.AddFlags(cmd.Flags())
 

--- a/pkg/imagevector/imagevector.go
+++ b/pkg/imagevector/imagevector.go
@@ -15,7 +15,6 @@
 package imagevector
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/gardener/gardener-extension-runtime-gvisor/charts"
@@ -37,9 +36,8 @@ func init() {
 	imageVector, err = imagevector.WithEnvOverride(imageVector)
 	runtime.Must(err)
 
-	image, err := imageVector.FindImage(gvisor.RuntimeGVisorInstallationImageName)
+	_, err = imageVector.FindImage(gvisor.RuntimeGVisorInstallationImageName)
 	runtime.Must(err)
-	fmt.Printf("Image %q - using image name: %q \n", gvisor.RuntimeGVisorInstallationImageName, image.String())
 }
 
 // ImageVector is the image vector that contains all the needed images.


### PR DESCRIPTION
Added support for a "version" subcommand. Also  removed hardcoded printout interfering with new subcommand operation.

**Release note**:
```improvement operator
Gardener gVisor extension now supports a "version" command line subcommand which prints the current program version.
```
