### PR TITLE
Revert "[pipeline] Inject effective version"

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,7 +5,6 @@ gardener-extension-runtime-gvisor:
     traits:
       version:
         preprocess: 'inject-commit-hash'
-        inject_effective_version: true
       publish:
         dockerimages:
           gardener-extension-runtime-gvisor:


### PR DESCRIPTION
Reverts gardener/gardener-extension-runtime-gvisor#36

This change has broken the verify step due to the different version now in the [example/controller-registration.yaml](https://github.com/gardener/gardener-extension-runtime-gvisor/blob/master/example/controller-registration.yaml)