### PR TITLE
Fix the GitTreeState reported by the --version flag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 
 # Exclude folders relevant for build
 !.git/
+!.dockerignore
 !charts/
 !cmd/
 !docs/


### PR DESCRIPTION
/kind bug

Currently the `--version` flag reports a dirty GitTreeState even for the head-update build from the current master:
```
$ docker run eu.gcr.io/gardener-project/gardener/extensions/runtime-gvisor:v0.5.0-dev-2e5edbe50fc6d2c44ebfb833157b6f30564f9d63 --version=raw
version.Info{Major:"0", Minor:"5+", GitVersion:"v0.5.0-dev", GitCommit:"2e5edbe50fc6d2c44ebfb833157b6f30564f9d63", GitTreeState:"dirty", BuildDate:"2022-03-03T08:23:56+00:00", GoVersion:"go1.17.5", Compiler:"gc", Platform:"linux/amd64"}
```

In short, the `get-build-ld-flags.sh` script depends on the `.dockerignore` file to be present during docker build.

https://github.com/gardener/gardener-extension-runtime-gvisor/blob/2e5edbe50fc6d2c44ebfb833157b6f30564f9d63/vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh#L34-L40

You can also notice that docker build currently yields the following err:
```
Step 4/8 : RUN make install install-binaries
 ---> Running in 377d7664cde6
fatal: cannot use .dockerignore as an exclude file
> Install
```

Hence, in the `.dockerignore` file we have to exclude the  `.dockerignore` to make sure it is present during docker build.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
