### PR TITLE
Fix integration test TestDefinition

### DIFF
--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/integration/suites
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.16.6
+  image: eu.gcr.io/gardener-project/3rd/golang:1.17.9

--- a/test/integration/suites/run_suite_test.go
+++ b/test/integration/suites/run_suite_test.go
@@ -54,5 +54,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGardenerSuite(t *testing.T) {
-	RunSpecsWithDefaultAndCustomReporters(t, "AWS Test Suite", []Reporter{reporter.NewGardenerESReporter(*reportFilePath, *esIndex)})
+	RunSpecs(t, "gVisor Test Suite")
 }
+
+var _ = ReportAfterSuite("Report to Elasticsearch", func(report Report) {
+	reporter.ReportResults(*reportFilePath, *esIndex, report)
+})


### PR DESCRIPTION
/area testing
/kind bug

1. Currently with `golang:1.16.6` the test execution fails with:
   ```
   # sigs.k8s.io/json/internal/golang/encoding/json
   vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
   vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
   ```
   
   To fix the TestDefinition image is updated to go1.17.

2. Next, the test execution failed with:

   ```
   # github.com/gardener/gardener-extension-runtime-gvisor/test/integration/suites_test [github.com/gardener/gardener-extension-runtime-gvisor/test/integration/suites.test]
   test/integration/suites/run_suite_test.go:57:72: undefined: reporter.NewGardenerESReporter
   ```
   
   `test/integration/suites/run_suite_test.go` has to be adapted to fix the build failure.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix developer
An issue causing the integration test execution to fail due to outdated golang version is now fixed.
```
