### PR TITLE
[release-v0.5] Automated cherry pick of #45: Fix integration test TestDefinition

### DIFF
--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/integration/suites
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.16.6
+  image: eu.gcr.io/gardener-project/3rd/golang:1.17.9

--- a/test/integration/suites/run_suite_test.go
+++ b/test/integration/suites/run_suite_test.go
@@ -54,5 +54,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestGardenerSuite(t *testing.T) {
-	RunSpecsWithDefaultAndCustomReporters(t, "AWS Test Suite", []Reporter{reporter.NewGardenerESReporter(*reportFilePath, *esIndex)})
+	RunSpecs(t, "gVisor Test Suite")
 }
+
+var _ = ReportAfterSuite("Report to Elasticsearch", func(report Report) {
+	reporter.ReportResults(*reportFilePath, *esIndex, report)
+})


### PR DESCRIPTION
/kind/bug
/area/testing

Cherry pick of #45 on release-v0.5.

#45: Fix integration test TestDefinition

**Release Notes:**
```bugfix developer
An issue causing the integration test execution to fail due to outdated golang version is now fixed.
```