### PR TITLE
Change extension's base image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /go/src/github.com/gardener/gardener-extension-runtime-gvisor
 COPY . .
 RUN make install install-binaries
 ############# gardener-extension-runtime-gvisor
-FROM scratch AS gardener-extension-runtime-gvisor
+FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-runtime-gvisor
+WORKDIR /
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-runtime-gvisor /gardener-extension-runtime-gvisor


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the base image of the extension to `distroless` and uses a non root user by default.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The extension container now uses `distroless` as a base image.
```
