### PR TITLE
Remove install-requirement and use tools.mk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /local
 **/dev
 /bin
+hack/tools/bin
 
 *.coverprofile
 *.html


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts the tool concept according to https://github.com/gardener/gardener/issues/6396 and removes the install-requirement script to install dependencies required for development on the fly and as needed.
See a detailed explanation/motivation in https://github.com/gardener/gardener/pull/4879.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6396

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
