### PR TITLE
Update alpine version to 3.16.1 and go version to 1.18.5

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,9 @@
 run:
   concurrency: 4
   deadline: 10m
+  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
+  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
+  go: "1.17"
 
 linters:
   disable:

--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.17.9
+  image: eu.gcr.io/gardener-project/3rd/golang:1.18.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.17.9 AS builder
+FROM golang:1.18.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-runtime-gvisor
 COPY . .
@@ -13,7 +13,7 @@ COPY --from=builder /go/bin/gardener-extension-runtime-gvisor /gardener-extensio
 ENTRYPOINT ["/gardener-extension-runtime-gvisor"]
 
 ############# gardener-extension-runtime-gvisor-installation for the installation daemonSet
-FROM alpine:3.15.4 AS gardener-extension-runtime-gvisor-installation
+FROM alpine:3.16.1 AS gardener-extension-runtime-gvisor-installation
 
 COPY --from=builder /usr/local/bin/containerd-shim-runsc-v1 /var/content/containerd-shim-runsc-v1
 COPY --from=builder /usr/local/bin/runsc /var/content/runsc


### PR DESCRIPTION
**What this PR does / why we need it**:
Update alpine and go version to get rid of:
Alpine issues:
  - [CVE-2022-2068](https://nvd.nist.gov/vuln/detail/CVE-2022-2068) 
  - [CVE-2022-2097](https://nvd.nist.gov/vuln/detail/CVE-2022-2097)
 Go issues:
  - [CVE-2022-29526](https://nvd.nist.gov/vuln/detail/CVE-2022-29526)
  - [CVE-2022-30634](https://nvd.nist.gov/vuln/detail/CVE-2022-30634)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@danielfoehrKn Could you cut a new release when this PR is merged?
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Updated the alpine base image for the installation pods to 3.16.1.
```
```improvement operator
Golang version is updated to 1.18.5
```
