### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/gvisor/templates/psp-gvisor.yaml
+++ b/charts/internal/gvisor/templates/psp-gvisor.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -22,3 +23,4 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
+{{- end }}

--- a/charts/internal/gvisor/templates/rbac-gvisor.yaml
+++ b/charts/internal/gvisor/templates/rbac-gvisor.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -25,3 +26,4 @@ subjects:
   - kind: ServiceAccount
     name: gvisor
     namespace: kube-system
+{{- end }}

--- a/charts/internal/gvisor/values.yaml
+++ b/charts/internal/gvisor/values.yaml
@@ -1,2 +1,4 @@
 config:
   kubernetesVersion: 1.16.1
+
+pspDisabled: false

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Chart package test", func() {
 				"config": map[string]interface{}{
 					"kubernetesVersion": kubernetesVersion,
 				},
+				"pspDisabled": true,
 			}
 
 			mockChartRenderer.EXPECT().Render(gvisor.ChartPath, gvisor.ReleaseName, metav1.NamespaceSystem, gomock.Eq(renderedValues)).Return(&chartrenderer.RenderedChart{
@@ -82,7 +83,7 @@ var _ = Describe("Chart package test", func() {
 				},
 			}, nil)
 
-			_, err := charts.RenderGVisorChart(mockChartRenderer, kubernetesVersion)
+			_, err := charts.RenderGVisorChart(mockChartRenderer, kubernetesVersion, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -57,13 +57,14 @@ func RenderGVisorInstallationChart(renderer chartrenderer.Interface, cr *extensi
 }
 
 // RenderGVisorChart renders the gVisor chart
-func RenderGVisorChart(renderer chartrenderer.Interface, kubernetesVersion string) ([]byte, error) {
+func RenderGVisorChart(renderer chartrenderer.Interface, kubernetesVersion string, pspDisabled bool) ([]byte, error) {
 	configChartValues := map[string]interface{}{
 		"kubernetesVersion": kubernetesVersion,
 	}
 
 	gvisorChartValues := map[string]interface{}{
-		"config": configChartValues,
+		"config":      configChartValues,
+		"pspDisabled": pspDisabled,
 	}
 
 	release, err := renderer.Render(gvisor.ChartPath, gvisor.ReleaseName, metav1.NamespaceSystem, gvisorChartValues)

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -57,7 +58,8 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, cr *extension
 		}
 		log.Info("Preparing gVisor installation", "shoot", cluster.Shoot.Name, "shootNamespace", cluster.Shoot.Namespace)
 		// create MR containing the prerequisites for the installation DaemonSet
-		gVisorChart, err := charts.RenderGVisorChart(chartRenderer, cluster.Shoot.Spec.Kubernetes.Version)
+		pspDisabled := gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot)
+		gVisorChart, err := charts.RenderGVisorChart(chartRenderer, cluster.Shoot.Spec.Kubernetes.Version, pspDisabled)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `runtime-gvisor` if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:

/area open-source
/kind enhancement
/squash
/hold depends on #55 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking operator
Please make sure you're running gardener@v1.53 or above before upgrading to this version.
```
