### PR TITLE
Handle `RuntimeClass` `node.k8s.io/v1`

### DIFF
--- a/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
+++ b/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
@@ -1,4 +1,8 @@
+{{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: node.k8s.io/v1
+{{- else }}
 apiVersion: node.k8s.io/v1beta1
+{{- end }}
 kind: RuntimeClass
 metadata:
   name: gvisor


### PR DESCRIPTION
**What this PR does / why we need it**:
RuntimeClass in the node.k8s.io/v1beta1 API version will no longer be served in v1.25. [Ref](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#runtimeclass-v125)

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6567

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
