### PR TITLE
Use multi-arch image of `busybox`

### DIFF
--- a/test/integration/container-runtime/container_runtime.go
+++ b/test/integration/container-runtime/container_runtime.go
@@ -239,7 +239,7 @@ func deployGVisorPod(ctx context.Context, c client.Client) (*corev1.Pod, error) 
 			Containers: []corev1.Container{
 				{
 					Name:  "gvisor-container",
-					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.2",
+					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.3",
 					Command: []string{
 						"sleep",
 						"10000000",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the `busybox` test images to a multi-arch image.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
