### PR TITLE
Set seccomp profile to RuntimeDefault

### DIFF
--- a/charts/internal/gvisor-installation/templates/daemonset-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/daemonset-containerd.yaml
@@ -21,6 +21,11 @@ spec:
     spec:
       serviceAccountName: gvisor
       automountServiceAccountToken: false
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       hostPID: true
       hostIPC: true
       nodeSelector:

--- a/charts/internal/gvisor/templates/psp-gvisor.yaml
+++ b/charts/internal/gvisor/templates/psp-gvisor.yaml
@@ -2,6 +2,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gvisor
   namespace: kube-system
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the `securityContext` of daemonset pods by adding a seccomp profile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The daemonset pods now have their seccomp profiles set to "RuntimeDefault".
```
