### PR TITLE
Remove support for Shoots with Kubernetes version < 1.17

### DIFF
--- a/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
+++ b/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
@@ -7,8 +7,6 @@ kind: RuntimeClass
 metadata:
   name: gvisor
 handler: runsc
-{{- if semverCompare "> 1.15" .Values.config.kubernetesVersion }}
 scheduling:
   nodeSelector:
     containerruntime.worker.gardener.cloud/gvisor: "true"
-{{- end }}

--- a/charts/internal/gvisor/values.yaml
+++ b/charts/internal/gvisor/values.yaml
@@ -1,4 +1,1 @@
-config:
-  kubernetesVersion: 1.16.1
-
 pspDisabled: false

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -41,8 +41,7 @@ var _ = Describe("Chart package test", func() {
 			mkManifest          = func(name string) manifest.Manifest {
 				return manifest.Manifest{Name: fmt.Sprintf("test/templates/%s", name), Content: testManifestContent}
 			}
-			workerGroup       = "worker-gvisor"
-			kubernetesVersion = "1.0.0"
+			workerGroup = "worker-gvisor"
 
 			cr = extensionsv1alpha1.ContainerRuntime{
 				Spec: extensionsv1alpha1.ContainerRuntimeSpec{
@@ -70,9 +69,6 @@ var _ = Describe("Chart package test", func() {
 
 		It("Render Gvisor chart correctly", func() {
 			renderedValues := map[string]interface{}{
-				"config": map[string]interface{}{
-					"kubernetesVersion": kubernetesVersion,
-				},
 				"pspDisabled": true,
 			}
 
@@ -83,7 +79,7 @@ var _ = Describe("Chart package test", func() {
 				},
 			}, nil)
 
-			_, err := charts.RenderGVisorChart(mockChartRenderer, kubernetesVersion, true)
+			_, err := charts.RenderGVisorChart(mockChartRenderer, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -57,13 +57,8 @@ func RenderGVisorInstallationChart(renderer chartrenderer.Interface, cr *extensi
 }
 
 // RenderGVisorChart renders the gVisor chart
-func RenderGVisorChart(renderer chartrenderer.Interface, kubernetesVersion string, pspDisabled bool) ([]byte, error) {
-	configChartValues := map[string]interface{}{
-		"kubernetesVersion": kubernetesVersion,
-	}
-
+func RenderGVisorChart(renderer chartrenderer.Interface, pspDisabled bool) ([]byte, error) {
 	gvisorChartValues := map[string]interface{}{
-		"config":      configChartValues,
 		"pspDisabled": pspDisabled,
 	}
 

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -50,7 +50,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, cr *extension
 	log.Info("Preparing gVisor installation", "shoot", cluster.Shoot.Name, "shootNamespace", cluster.Shoot.Namespace)
 	// create MR containing the prerequisites for the installation DaemonSet
 	pspDisabled := gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot)
-	gVisorChart, err := charts.RenderGVisorChart(chartRenderer, cluster.Shoot.Spec.Kubernetes.Version, pspDisabled)
+	gVisorChart, err := charts.RenderGVisorChart(chartRenderer, pspDisabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	shootVersion = "1.14.0"
+	shootVersion = "1.24.0"
 )
 
 var _ = Describe("Chart package test", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-provider-aws/issues/595

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking operator
runtime-gvisor no longer supports Shoots with Кubernetes version < 1.17.
```
