### PR TITLE
Update alpine version to 3.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# binaries-installer
-FROM alpine:3.16.1 AS binaries-installer
+FROM alpine:3.16.2 AS binaries-installer
 
 COPY hack/ hack/
 COPY GVISOR_VERSION ./
@@ -22,7 +22,7 @@ COPY --from=builder /go/bin/gardener-extension-runtime-gvisor /gardener-extensio
 ENTRYPOINT ["/gardener-extension-runtime-gvisor"]
 
 ############# gardener-extension-runtime-gvisor-installation for the installation daemonSet
-FROM alpine:3.16.1 AS gardener-extension-runtime-gvisor-installation
+FROM alpine:3.16.2 AS gardener-extension-runtime-gvisor-installation
 
 COPY --from=binaries-installer /usr/local/bin/containerd-shim-runsc-v1 /var/content/containerd-shim-runsc-v1
 COPY --from=binaries-installer /usr/local/bin/runsc /var/content/runsc


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Update `alpine` version to `3.16.2` to mitigate :
[CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434)



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update alpine version to `3.16.2`.
```
