### PR TITLE
Drop support for kubernetes < 1.20 for runtime gvisor extension

### DIFF
--- a/charts/internal/gvisor-installation/templates/daemonset-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/daemonset-containerd.yaml
@@ -21,11 +21,9 @@ spec:
     spec:
       serviceAccountName: gvisor
       automountServiceAccountToken: false
-      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      {{- end }}
       hostPID: true
       hostIPC: true
       nodeSelector:

--- a/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
+++ b/charts/internal/gvisor/templates/runtimeclass-gvisor.yaml
@@ -1,8 +1,4 @@
-{{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: node.k8s.io/v1
-{{- else }}
-apiVersion: node.k8s.io/v1beta1
-{{- end }}
 kind: RuntimeClass
 metadata:
   name: gvisor

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for kubernetes < 1.20 for runtime gvisor extension

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```other operator
runtime-gvisor no longer supports Shoots with Кubernetes version < 1.20.
```
