### PR TITLE
Assign gvisor team members as code owners in pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -16,11 +16,29 @@ gardener-extension-runtime-gvisor:
             image: 'eu.gcr.io/gardener-project/gardener/extensions/runtime-gvisor'
             dockerfile: 'Dockerfile'
             target: gardener-extension-runtime-gvisor
+            resource_labels:
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubUser'
+                username: 'marwinski'
+              - type: 'githubUser'
+                username: 'MrBatschner'
+              - type: 'githubUser'
+                username: 'danielfoehrKn'
           gardener-extension-runtime-gvisor-installation:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/extensions/runtime-gvisor-installation'
             dockerfile: 'Dockerfile'
             target: gardener-extension-runtime-gvisor-installation
+            resource_labels:
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubUser'
+                username: 'marwinski'
+              - type: 'githubUser'
+                username: 'MrBatschner'
+              - type: 'githubUser'
+                username: 'danielfoehrKn'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Assign @gardener/gardener-extension-runtime-gvisor-maintainers  team members as code owners in pipeline definition


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @marwinski @MrBatschner @danielfoehrKn
cc @JordanJordanov
/invite @ccwienk @zkdev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
