### PR TITLE
Enable dependabot for updating the `github.com/gardener/gardener` dependency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+# Create PRs for github.com/gardener/gardener dependency updates
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
+# Create PRs for golang and alpine version updates
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+- package-ecosystem: docker
+  directory: /.test-defs
+  schedule:
+    interval: daily

--- a/.github/workflows/vendor_gardener.yaml
+++ b/.github/workflows/vendor_gardener.yaml
@@ -1,0 +1,35 @@
+name: Vendor Gardener
+on:
+  push:
+    branches:
+    - dependabot/go_modules/github.com/gardener/**
+permissions: write-all
+jobs:
+  run:
+    name: Run make revendor
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+
+    - name: Use gardener's replaced client-go version
+      run: go mod edit -replace 'k8s.io/client-go=k8s.io/client-go@'"$(go list -m -f '{{.Version}}' k8s.io/api)"
+
+    - name: Make revendor
+      run: make revendor
+    - name: Commit changes
+      run: |
+        # Exit early if there is nothing to commit. This can happen if someone pushes to the dependabot's PR (for example has to adapt to a breaking change).
+        if [[ -z $(git status --porcelain) ]]; then
+          echo "Nothing to commit, working tree clean. Exiting..."
+          exit 0
+        fi
+        
+        git config user.name gardener-robot-ci-1
+        git config user.email gardener.ci.user@gmail.com
+
+        git add .
+        git commit -m "[dependabot skip] make revendor"
+        git push origin

--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -1,3 +1,4 @@
+apiVersion: testmachinery.sapcloud.io
 kind: TestDefinition
 metadata:
   name: gvisor-beta-serial-test-suite

--- a/.test-defs/TestSuiteGvisorBetaSerial.yaml
+++ b/.test-defs/TestSuiteGvisorBetaSerial.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: eu.gcr.io/gardener-project/3rd/golang:1.19.3
+  image: golang:1.20.7


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
I noticed that currently the gvisor integration tests against K8s 1.27 Shoots fails with
```

2023-08-04T05:47:35.471598675Z stdout F   In [BeforeEach] at: /src/vendor/github.com/gardener/gardener/test/framework/shootframework.go:96 @ 08/04/23 05:47:34.658
2023-08-04T05:47:35.471592966Z stdout F   occurred
2023-08-04T05:47:35.471587868Z stdout F       }
2023-08-04T05:47:35.471582416Z stdout F           },
2023-08-04T05:47:35.47157768Z stdout F               },
2023-08-04T05:47:35.471572758Z stdout F                   },
2023-08-04T05:47:35.471566592Z stdout F                       s: "unsupported kubernetes version \"v1.27.4\"",
2023-08-04T05:47:35.471560488Z stdout F                   err: <*errors.errorString | 0xc000125830>{
2023-08-04T05:47:35.471555398Z stdout F                   msg: "error discovering kubernetes version: unsupported kubernetes version \"v1.27.4\"",
2023-08-04T05:47:35.471548559Z stdout F               err: <*fmt.wrapError | 0xc000b566e0>{
2023-08-04T05:47:35.471542265Z stdout F               msg: "could not construct Shoot client: error discovering kubernetes version: unsupported kubernetes version \"v1.27.4\"",
2023-08-04T05:47:35.471536218Z stdout F           err: <*fmt.wrapError | 0xc000b56720>{
2023-08-04T05:47:35.471530755Z stdout F           ctxError: <context.deadlineExceededError>{},
2023-08-04T05:47:35.47152382Z stdout F       {
2023-08-04T05:47:35.471517461Z stdout F       retry failed with context deadline exceeded, last error: could not construct Shoot client: error discovering kubernetes version: unsupported kubernetes version "v1.27.4"
2023-08-04T05:47:35.471506925Z stdout F       <*retry.Error | 0xc000d16760>: 
```

The issue is described in https://github.com/gardener/gardener-extension-runtime-gvisor/issues/27. 

TL;DR short term, gardener/gardener >= 1.71.0 has to be vendored (to include https://github.com/gardener/gardener/commit/7489574cf91eb6c5ad5f2ed3597104b7d0163145).

I decided to enable dependabot for this repo to automate as much as possible the process of vendoring the `github.com/gardener/gardener` dependency.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6328

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
