### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,16 @@
 gardener-extension-runtime-gvisor:
+  templates: 
+    helmcharts:
+    - &runtime-gvisor
+      name: runtime-gvisor
+      dir: charts/gardener-extension-runtime-gvisor
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-runtime-gvisor.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-runtime-gvisor.tag
+        attribute: image.tag
+
   base_definition:
     traits:
       version:
@@ -46,6 +58,9 @@ gardener-extension-runtime-gvisor:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *runtime-gvisor
     pull-request:
       traits:
         pull-request: ~
@@ -54,6 +69,9 @@ gardener-extension-runtime-gvisor:
              - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *runtime-gvisor
     release:
       traits:
         version:
@@ -78,3 +96,6 @@ gardener-extension-runtime-gvisor:
             gardener-extension-runtime-gvisor-installation:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/runtime-gvisor-installation
               tag_as_latest: true
+          helmcharts:
+          - <<: *runtime-gvisor
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
