### PR TITLE
enable gosec for static code analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ TODO
 # Virtual go & fuse
 .virtualgo
 .fuse_hidden*
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -115,19 +115,12 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(M
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg
 
-# TODO(MrBatschner): Remove once this extension is revendored against g/g >= 1.106
-TOOLS_PKG_PATH := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
-.PHONY: adjust-install-gosec.sh
-adjust-install-gosec.sh:
-	@chmod +xw $(TOOLS_PKG_PATH)/install-gosec.sh
-
-
 .PHONY: sast
-sast: adjust-install-gosec.sh $(GOSEC)
+sast: $(GOSEC)
 	@./hack/sast.sh
 
 .PHONY: sast-report
-sast-report: adjust-install-gosec.sh $(GOSEC)
+sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: test

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+
+# shellcheck disable=SC2086
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -36,7 +36,7 @@ func init() {
 
 // LoadFromFile takes a filename and de-serializes the contents into ControllerConfiguration object.
 func LoadFromFile(filename string) (*config.ControllerConfiguration, error) {
-	bytes, err := os.ReadFile(filename)
+	bytes, err := os.ReadFile(filename) // #nosec G304 -- LoadFromFile should load from a file
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

Following https://github.com/gardener/gardener/pull/9959, this PR enables Static Application Security Testing (SAST) with `gosec` on this repo.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Static Application Security Testing (sast) with `gosec` got enabled on this repository.
```
