### PR TITLE
Add Roncossek as responsible for this repository in component-descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,11 +31,9 @@ gardener-extension-runtime-gvisor:
             - name: 'cloud.gardener.cnudie/responsibles'
               value:
               - type: 'githubUser'
-                username: 'marwinski'
-              - type: 'githubUser'
                 username: 'MrBatschner'
               - type: 'githubUser'
-                username: 'danielfoehrKn'
+                username: 'Roncossek'
           gardener-extension-runtime-gvisor-installation:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/runtime-gvisor-installation
             dockerfile: 'Dockerfile'
@@ -44,11 +42,9 @@ gardener-extension-runtime-gvisor:
             - name: 'cloud.gardener.cnudie/responsibles'
               value:
               - type: 'githubUser'
-                username: 'marwinski'
-              - type: 'githubUser'
                 username: 'MrBatschner'
               - type: 'githubUser'
-                username: 'danielfoehrKn'
+                username: 'Roncossek'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Roncossek as responsible for this repository in component-descriptor.
Removes danielfoehrKn and marwinski from the list of responsibles for this repository in component-descriptor.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```