### PR TITLE
Collect SAST assets in release pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -76,6 +76,16 @@ gardener-extension-runtime-gvisor:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+              We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
+              Enabled by https://github.com/gardener/gardener-extension-runtime-gvisor/pull/155
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:


### PR DESCRIPTION
**What this PR does / why we need it**:

Modifies the release pipeline to collect the assets produced during static code analysis (SAST) and attach them to the component-descriptor. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
SAST assets are now collected in the release pipeline and attached to the component-descriptor.
```
