### PR TITLE
Fix bump-gVisor script compatibility with urllib3 v1

### DIFF
--- a/.ci/check_and_bump_gvisor_version.py
+++ b/.ci/check_and_bump_gvisor_version.py
@@ -49,7 +49,7 @@ def get_upstream_version_from_tags(organization: str, repository: str) -> str:
     api_root = 'api.github.com'
     url = f"https://{api_root}/repos/{organization}/{repository}/tags"
 
-    resp=urllib3.request("GET", url)
+    resp=urllib3.PoolManager().request("GET", url)
     if resp.status != 200:
         raise RuntimeError(f"GitHub API did not return 200 status")
     


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the compatibilitiy of the `check_and_bump_gvisor_version.py` script introduced in PR #184 with urllib3 v1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
