### PR TITLE
Allow turning on runsc debug logs via providerConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ GVisor can be configured with additional configuration flags by adding them to t
                 apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
                 kind: GVisorConfiguration
                 configFlags:
-                  "net-raw" "true"
+                  net-raw: "true"
                   ...
 ...
 ```
@@ -73,6 +73,24 @@ spec:
       matchLabels:
         worker.gardener.cloud/pool: worker-xyz
 ```
+
+## Debugging
+
+runsc can produce additional debug logs which are helpful when Pods do not start or do not properly terminate. To turn debug logs on, the config flag `debug` can be set:
+
+```yaml
+...
+            - type: gvisor
+              providerConfig:
+                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+                kind: GVisorConfiguration
+                configFlags:
+                  debug: "true"
+                  ...
+...
+```
+
+With this setting, runsc will create debug logs for each and every container in `/var/log/runsc/<containerd-id>/<command>-gvisor.log` on a node.
 
 ---
 

--- a/charts/internal/gvisor-installation/values.yaml
+++ b/charts/internal/gvisor-installation/values.yaml
@@ -9,3 +9,4 @@ config:
     worker.gardener.cloud/pool: gvisor-pool
   configFlags: |
     net-raw = "false"
+    debug = "false"

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -114,10 +114,14 @@ kind: GVisorConfiguration`
 			testCases := map[string]ProviderConfigTestCase{
 				"no-flags": {providerConfig: providerConfigBase,
 					expectedConfigFlags: ""},
-				"all-flags": {providerConfig: providerConfigBase + `
+				"net-raw-flag": {providerConfig: providerConfigBase + `
 configFlags:
   "net-raw": "true"`,
 					expectedConfigFlags: "net-raw = \"true\"\n"},
+				"debug-flag": {providerConfig: providerConfigBase + `
+configFlags:
+  "debug": "true"`,
+					expectedConfigFlags: "debug = \"true\"\ndebug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\""},
 			}
 
 			for testName, testCase := range testCases {

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -41,15 +41,18 @@ func RenderGVisorInstallationChart(renderer chartrenderer.Interface, cr *extensi
 		}
 	}
 
-	runscConfig := ""
+	runscConfigFlags := ""
 	if providerConfig.ConfigFlags != nil && len(*providerConfig.ConfigFlags) > 0 {
 		for key, value := range *providerConfig.ConfigFlags {
 			// the API allows to set arbitrary flags, but we only allow the following flags for now
 			// A list of all supported flags can be found here: https://github.com/google/gvisor/blob/master/runsc/config/flags.go
 			if key == "net-raw" && (value == "true" || value == "false") {
-				runscConfig += fmt.Sprintf("%s = \"%s\"\n", key, value)
+				runscConfigFlags += fmt.Sprintf("%s = \"%s\"\n", key, value)
 			}
-
+			if key == "debug" && value == "true" {
+				runscConfigFlags += fmt.Sprintf("%s = \"%s\"\n", key, "true")
+				runscConfigFlags += "debug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\""
+			}
 		}
 	}
 
@@ -65,7 +68,7 @@ func RenderGVisorInstallationChart(renderer chartrenderer.Interface, cr *extensi
 		"binFolder":    cr.Spec.BinaryPath,
 		"nodeSelector": nodeSelectorValue,
 		"workergroup":  cr.Spec.WorkerPool.Name,
-		"configFlags":  runscConfig,
+		"configFlags":  runscConfigFlags,
 	}
 
 	gvisorChartValues := map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to be able to debug problems with Pods that use a `gVisor` RuntimeClass, it may be necessary to turn on debug logs for runsc by putting something like

```
[runsc_config]
  debug = "true"
  debug-log = "/var/log/runsc/%ID%/gvisor.log"
```

into `/etc/containerd/runsc.toml`. With this PR, it will be possible to provide a `debug: "true"` directive in the ProviderConfig for the gVisor runtime which will then configure `/etc/containerd/runsc.toml` accordingly.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement user
If debugging of workloads in gVisor is required, runsc debug logs can be turned on by specifying `debug: "true"` in the gVisor providerConfig.
```
