### PR TITLE
NVIDIA GPUs support via nvproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
 gVisor can be configured with additional configuration flags by adding them to the `configFlags` field in the providerConfig. 
 Right now the following flags are supported and all other flags are ignored:
 - `debug: "true"`: This enables debug logs for runsc. The logs are written to `/var/log/runsc/<containerd-id>/<command>-gvisor.log` on the node.
-- `net-raw: "true`: This is required for some applications that need to use raw sockets, such as `traceroute`, or `istio` init conainers.
+- `net-raw: "true"`: This is required for some applications that need to use raw sockets, such as `traceroute`, or `istio` init conainers.
 - `nvproxy: "true"`: Run GPU enabled containers in your gVisor sandbox. This flag is required for the NVIDIA GPU device plugin to work with gVisor.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ spec:
     ...
 ```
 
-GVisor can be configured with additional configuration flags by adding them to the `configFlags` field in the providerConfig. Right now we only allow the `"net-raw"` flag to be set. All other flags are ignored.
+gVisor can be configured with additional configuration flags by adding them to the `configFlags` field in the providerConfig. 
+Right now the following flags are supported and all other flags are ignored:
+- `debug: "true"`: This enables debug logs for runsc. The logs are written to `/var/log/runsc/<containerd-id>/<command>-gvisor.log` on the node.
+- `net-raw: "true`: This is required for some applications that need to use raw sockets, such as `traceroute`, or `istio` init conainers.
+- `nvproxy: "true"`: Run GPU enabled containers in your gVisor sandbox. This flag is required for the NVIDIA GPU device plugin to work with gVisor.
 
 ```yaml
 ...
@@ -46,7 +50,9 @@ GVisor can be configured with additional configuration flags by adding them to t
                 apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
                 kind: GVisorConfiguration
                 configFlags:
+                  debug: "true"
                   net-raw: "true"
+                  nvproxy: "true"
                   ...
 ...
 ```
@@ -91,6 +97,51 @@ runsc can produce additional debug logs which are helpful when Pods do not start
 ```
 
 With this setting, runsc will create debug logs for each and every container in `/var/log/runsc/<containerd-id>/<command>-gvisor.log` on a node.
+
+
+## NVProxy Usage
+
+gvisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag must be set in the gvisor providerConfig of the shoot:
+
+```yaml
+...
+            - type: gvisor
+              providerConfig:
+                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+                kind: GVisorConfiguration
+                configFlags:
+                  nvproxy: "true"
+                  ...
+...
+```
+
+### Pre-requisites
+- The required NVIDIA drivers must be installed on the nodes. 
+  - In case of Gardenlinux, the [gardenlinux-nvidia-installer](https://github.com/gardenlinux/gardenlinux-nvidia-installer) can be used.
+  - ⚠ Please note that the gardenlinux-nvidia-installer version must match the gardenlinux version.
+- The [NVIDIA device plugin](https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#nvidia-device-plugin-for-kubernetes) must be installed in the cluster.
+
+### Known limitations:
+
+gVisor does not support all NVIDIA GPUs and drivers. Please refer to the [gVisor documentation](https://gvisor.dev/docs/user_guide/gpu/) for detailed information.
+
+Before using gVisor with NVIDIA GPUs, please check the supporded drivers by running the following command on your node with enabled gVisor:
+
+```bash
+$ /var/bin/containerruntimes/runsc nvproxy list-supported-drivers
+535.183.01
+535.183.06
+535.216.01
+535.230.02
+550.54.14
+550.54.15
+550.90.07
+550.90.12
+550.127.05
+560.35.03
+565.57.01
+570.86.15
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Right now the following flags are supported and all other flags are ignored:
 ...
             - type: gvisor
               providerConfig:
-                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+                apiVersion: gvisor.runtime.extensions.config.gardener.cloud/v1alpha1
                 kind: GVisorConfiguration
                 configFlags:
                   debug: "true"
@@ -80,25 +80,6 @@ spec:
         worker.gardener.cloud/pool: worker-xyz
 ```
 
-## Debugging
-
-runsc can produce additional debug logs which are helpful when Pods do not start or do not properly terminate. To turn debug logs on, the config flag `debug` can be set:
-
-```yaml
-...
-            - type: gvisor
-              providerConfig:
-                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
-                kind: GVisorConfiguration
-                configFlags:
-                  debug: "true"
-                  ...
-...
-```
-
-With this setting, runsc will create debug logs for each and every container in `/var/log/runsc/<containerd-id>/<command>-gvisor.log` on a node.
-
-
 ## NVProxy Usage
 
 gVisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag must be set in the gVisor providerConfig of the shoot:
@@ -107,7 +88,7 @@ gVisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag m
 ...
             - type: gvisor
               providerConfig:
-                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+                apiVersion: gvisor.runtime.extensions.config.gardener.cloud/v1alpha1
                 kind: GVisorConfiguration
                 configFlags:
                   nvproxy: "true"
@@ -116,6 +97,7 @@ gVisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag m
 ```
 
 ### Pre-requisites
+
 - The required NVIDIA drivers must be installed on the nodes. 
   - In case of Gardenlinux, the [gardenlinux-nvidia-installer](https://github.com/gardenlinux/gardenlinux-nvidia-installer) can be used.
   - ⚠ Please note that the gardenlinux-nvidia-installer version must match the gardenlinux version.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ With this setting, runsc will create debug logs for each and every container in 
 
 ## NVProxy Usage
 
-gvisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag must be set in the gvisor providerConfig of the shoot:
+gVisor can be used with NVIDIA GPUs. To enable this, the `nvproxy` config flag must be set in the gVisor providerConfig of the shoot:
 
 ```yaml
 ...

--- a/charts/internal/gvisor-installation/values.yaml
+++ b/charts/internal/gvisor-installation/values.yaml
@@ -10,3 +10,4 @@ config:
   configFlags: |
     net-raw = "false"
     debug = "false"
+    nvproxy = "false"

--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -15,7 +15,7 @@ spec:
             - type: gvisor
 # If you need a custom configuration, you can specify additional config flags
 #              providerConfig:
-#                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+#                apiVersion: gvisor.runtime.extensions.config.gardener.cloud/v1alpha1
 #                kind: GVisorConfiguration
 #                configFlags:
 #                  net-raw: "true"

--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -13,10 +13,13 @@ spec:
           name: containerd
           containerRuntimes:
             - type: gvisor
-              providerConfig:
-                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
-                kind: GVisorConfiguration
-                configFlags:
-                  "net-raw": "true"
+# If you need a custom configuration, you can specify additional config flags
+#              providerConfig:
+#                apiVersion: gvisor.os.extensions.gardener.cloud/v1alpha1
+#                kind: GVisorConfiguration
+#                configFlags:
+#                  net-raw: "true"
+#                  nvproxy: "true"
+#                  debug: "true"
 ...
 

--- a/pkg/apis/config/v1alpha1/register.go
+++ b/pkg/apis/config/v1alpha1/register.go
@@ -39,6 +39,7 @@ func init() {
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&ControllerConfiguration{},
+		&GVisorConfiguration{},
 	)
 	return nil
 }

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -6,7 +6,7 @@ package charts_test
 
 import (
 	"fmt"
-	gvisorconfiguration "github.com/gardener/gardener-extension-runtime-gvisor/pkg/apis/config/v1alpha1"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	mockchartrenderer "github.com/gardener/gardener/pkg/chartrenderer/mock"
@@ -20,6 +20,7 @@ import (
 
 	internalcharts "github.com/gardener/gardener-extension-runtime-gvisor/charts"
 	"github.com/gardener/gardener-extension-runtime-gvisor/imagevector"
+	gvisorconfiguration "github.com/gardener/gardener-extension-runtime-gvisor/pkg/apis/config/v1alpha1"
 	"github.com/gardener/gardener-extension-runtime-gvisor/pkg/charts"
 	"github.com/gardener/gardener-extension-runtime-gvisor/pkg/gvisor"
 )

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Chart package test", func() {
 			Entry("debug-flag",
 				map[string]string{"debug": "true"},
 				"debug = \"true\"\ndebug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\"\n"),
-			FEntry("all-flags",
+			Entry("all-flags",
 				map[string]string{"net-raw": "true", "debug": "true", "nvproxy": "true"},
 				// rendered alphabetically
 				`debug = "true"

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -16,7 +16,9 @@ import (
 	"helm.sh/helm/v3/pkg/releaseutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"
+	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
 
 	internalcharts "github.com/gardener/gardener-extension-runtime-gvisor/charts"
 	"github.com/gardener/gardener-extension-runtime-gvisor/imagevector"
@@ -104,7 +106,48 @@ var _ = Describe("Chart package test", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		DescribeTable("Render Gvisor installation chart correctly when provider config is provided",
+		DescribeTable("Provider config decoding",
+			func(providerConfig *gvisorconfiguration.GVisorConfiguration, expectedError string) {
+				rawJson, _ := json.Marshal(providerConfig)
+
+				cr.Spec.ProviderConfig = &runtime.RawExtension{Raw: rawJson}
+
+				_, err := charts.RenderGVisorInstallationChart(mockChartRenderer, &cr)
+				Expect(err.Error()).To(ContainSubstring(expectedError))
+			},
+			Entry("fail on invalid API",
+				&gvisorconfiguration.GVisorConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "some.group.com/v1alpha1",
+						Kind:       "GVisorConfiguration",
+					},
+					ConfigFlags: &map[string]string{"any": "flag"},
+				},
+				`no kind "GVisorConfiguration" is registered for version "some.group.com/v1alpha1" in scheme`,
+			),
+			Entry("fail on unsupported API version",
+				&gvisorconfiguration.GVisorConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gvisorconfiguration.GroupName + "/v1alpha2",
+						Kind:       "GVisorConfiguration",
+					},
+					ConfigFlags: &map[string]string{"any": "flag"},
+				},
+				`no kind "GVisorConfiguration" is registered for version "gvisor.runtime.extensions.config.gardener.cloud/v1alpha2" in scheme`,
+			),
+			Entry("fail on invalid Kind",
+				&gvisorconfiguration.GVisorConfiguration{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gvisorconfiguration.GroupName + "/v1alpha1",
+						Kind:       "ControllerConfiguration",
+					},
+					ConfigFlags: &map[string]string{"any": "flag"},
+				},
+				"converting (v1alpha1.ControllerConfiguration) to (v1alpha1.GVisorConfiguration): unknown conversion",
+			),
+		)
+
+		DescribeTable("Render Gvisor installation chart correctly with valid provider config",
 			func(configFlags map[string]string, expectedConfigFlags string) {
 				providerConfig := &gvisorconfiguration.GVisorConfiguration{
 					TypeMeta: metav1.TypeMeta{
@@ -113,9 +156,15 @@ var _ = Describe("Chart package test", func() {
 					},
 					ConfigFlags: &configFlags,
 				}
-				jsonData, _ := json.Marshal(providerConfig)
-				// set provider config
-				cr.Spec.ProviderConfig = &runtime.RawExtension{Raw: jsonData}
+
+				// this function acts as a little self test on schema encoding that is currently not used in production code.
+				rawJson, err := encodeProviderConfig(providerConfig)
+
+				// this indicates that either the provider config is incorrect
+				// or the scheme is not registered correctly
+				Expect(err).NotTo(HaveOccurred())
+
+				cr.Spec.ProviderConfig = &runtime.RawExtension{Raw: rawJson}
 
 				// provider config capabilities should be rendered into values
 				expectedHelmValues["config"].(map[string]interface{})["configFlags"] = expectedConfigFlags
@@ -127,7 +176,7 @@ var _ = Describe("Chart package test", func() {
 					},
 				}, nil)
 
-				_, err := charts.RenderGVisorInstallationChart(mockChartRenderer, &cr)
+				_, err = charts.RenderGVisorInstallationChart(mockChartRenderer, &cr)
 				Expect(err).NotTo(HaveOccurred())
 			},
 			Entry("no-flags", map[string]string{}, ""),
@@ -147,3 +196,21 @@ nvproxy = "true"
 		)
 	})
 })
+
+// helper function to encode the provider config to a raw JSON byte array
+// Note that this function will not be used in production code, but is a self test
+// It uses only the Go Type system to encode the provider config
+// the API version and Kind are not checked
+func encodeProviderConfig(providerConfig *gvisorconfiguration.GVisorConfiguration) ([]byte, error) {
+	scheme := runtime.NewScheme()
+	runtimeutils.Must(gvisorconfiguration.AddToScheme(scheme))
+	codecFactory := serializer.NewCodecFactory(scheme)
+	encoder := codecFactory.LegacyCodec(gvisorconfiguration.SchemeGroupVersion)
+
+	encoded, err := runtime.Encode(encoder, providerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not encode provider config: %w", err)
+	}
+
+	return encoded, nil
+}

--- a/pkg/charts/charts_test.go
+++ b/pkg/charts/charts_test.go
@@ -185,14 +185,6 @@ var _ = Describe("Chart package test", func() {
 			Entry("debug-flag",
 				map[string]string{"debug": "true"},
 				"debug = \"true\"\ndebug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\"\n"),
-			Entry("all-flags",
-				map[string]string{"net-raw": "true", "debug": "true", "nvproxy": "true"},
-				// rendered alphabetically
-				`debug = "true"
-debug-log = "/var/log/runsc/%ID%/gvisor-%COMMAND%.log"
-net-raw = "true"
-nvproxy = "true"
-`),
 		)
 	})
 })

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -51,7 +51,10 @@ func RenderGVisorInstallationChart(renderer chartrenderer.Interface, cr *extensi
 			}
 			if key == "debug" && value == "true" {
 				runscConfigFlags += fmt.Sprintf("%s = \"%s\"\n", key, "true")
-				runscConfigFlags += "debug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\""
+				runscConfigFlags += "debug-log = \"/var/log/runsc/%ID%/gvisor-%COMMAND%.log\"\n"
+			}
+			if key == "nvproxy" && value == "true" {
+				runscConfigFlags += fmt.Sprintf("%s = \"%s\"\n", key, "true")
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for the `nvproxy` config flag to enable gvisor pods to use NVIDIA GPUs.

**Which issue(s) this PR fixes**:
Fixes #198 

> **Release note**:

<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NVIDIA GPU support can be enabled by specifying `nvproxy: "true` in the gVisor providerConfig.
```
