### PR TITLE
Properly clean up `ManagedResources` during `migrate` phase of control plane migration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ LD_FLAGS := $(shell chmod +x $(LD_FLAGS_GENERATOR) && EFFECTIVE_VERSION=$(EFFECT
 # To update the runsc + shim binary:
 #  1) Download latest: https://storage.googleapis.com/gvisor/releases/release/latest/x86_64/runsc
 #  2) Execute runsc --version to find version
-#  3) Check that specific specific release can be downloaded: https://storage.googleapis.com/gvisor/releases/release/20230102.0/x86_64/runsc
+#  3) Check that specific release can be downloaded: https://storage.googleapis.com/gvisor/releases/release/20230102.0/x86_64/runsc
 #  4) Update version in GVISOR_VERSION file
 GVISOR_VERSION := $(shell cat GVISOR_VERSION)
 

--- a/pkg/controller/actuator_delete.go
+++ b/pkg/controller/actuator_delete.go
@@ -6,12 +6,10 @@ package controller
 
 import (
 	"context"
-	"time"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -43,21 +41,6 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, cr *extensionsv1
 	log.Info("Deleting managed resource - no worker pool in the Shoot cluster requires gVisor any more", "managedResourceName", GVisorManagedResourceName)
 
 	return a.deleteManagedResource(ctx, cr.Namespace, GVisorManagedResourceName, forceDelete)
-}
-
-func (a *actuator) deleteManagedResource(ctx context.Context, namespace, managedResourceName string, forceDelete bool) error {
-	if err := managedresources.Delete(ctx, a.client, namespace, managedResourceName, true); err != nil {
-		return err
-	}
-
-	if !forceDelete {
-		timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer cancel()
-
-		return managedresources.WaitUntilDeleted(timeoutCtx, a.client, namespace, managedResourceName)
-	}
-
-	return nil
 }
 
 func isGVisorInstallationRequired(name string, list *extensionsv1alpha1.ContainerRuntimeList) bool {

--- a/pkg/controller/actuator_delete.go
+++ b/pkg/controller/actuator_delete.go
@@ -19,12 +19,12 @@ import (
 // Delete implements ContainerRuntime.Actuator.
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster) error {
 	var (
-		managedResourceName = GVisorInstallationManagedResourceName + "-" + cr.Spec.WorkerPool.Name
-		forceDelete         = cluster != nil && v1beta1helper.ShootNeedsForceDeletion(cluster.Shoot)
+		installationManagedResourceName = GVisorInstallationManagedResourceName + "-" + cr.Spec.WorkerPool.Name
+		forceDelete                     = cluster != nil && v1beta1helper.ShootNeedsForceDeletion(cluster.Shoot)
 	)
 
-	log.Info("Deleting managed resource due to the deletion of the corresponding ContainerRuntime", "managedResourceName", managedResourceName, "namespace", cr.Namespace, "containerRuntime", cr.Name)
-	if err := a.deleteManagedResource(ctx, cr.Namespace, managedResourceName, forceDelete); err != nil {
+	log.Info("Deleting managed resource due to the deletion of the corresponding ContainerRuntime", "managedResourceName", installationManagedResourceName)
+	if err := a.deleteManagedResource(ctx, cr.Namespace, installationManagedResourceName, forceDelete); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, cr *extensionsv1
 	}
 
 	if isGVisorInstallationRequired(cr.Name, list) {
-		log.Info("gVisor is still required in the cluster - go ahead with ContainerRuntime deletion", "namespace", cr.Namespace, "containerRuntime", cr.Name)
+		log.Info("gVisor is still required in the cluster - go ahead with ContainerRuntime deletion")
 		return nil
 	}
 	log.Info("Deleting managed resource - no worker pool in the Shoot cluster requires gVisor any more", "managedResourceName", GVisorManagedResourceName)

--- a/pkg/controller/actuator_migrate.go
+++ b/pkg/controller/actuator_migrate.go
@@ -16,16 +16,16 @@ import (
 
 // Migrate implements ContainerRuntime.Actuator.
 func (a *actuator) Migrate(ctx context.Context, log logr.Logger, cr *extensionsv1alpha1.ContainerRuntime, _ *extensionscontroller.Cluster) error {
-	managedResourceName := GVisorInstallationManagedResourceName + "-" + cr.Spec.WorkerPool.Name
+	installationManagedResourceName := GVisorInstallationManagedResourceName + "-" + cr.Spec.WorkerPool.Name
 
-	log.Info("Setting keepObjects=true for managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", managedResourceName, "namespace", cr.Namespace, "containerRuntime", cr.Name)
-	if err := managedresources.SetKeepObjects(ctx, a.client, cr.Namespace, managedResourceName, true); err != nil {
-		return fmt.Errorf("could not keep objects of managed resource %q: %w", managedResourceName, err)
+	log.Info("Setting keepObjects=true for managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", installationManagedResourceName)
+	if err := managedresources.SetKeepObjects(ctx, a.client, cr.Namespace, installationManagedResourceName, true); err != nil {
+		return fmt.Errorf("could not keep objects of managed resource %q: %w", installationManagedResourceName, err)
 	}
 
-	log.Info("Deleting managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", managedResourceName, "namespace", cr.Namespace, "containerRuntime", cr.Name)
-	if err := a.deleteManagedResource(ctx, cr.Namespace, managedResourceName, false); err != nil {
-		return fmt.Errorf("could not delete managed resource %q: %w", managedResourceName, err)
+	log.Info("Deleting managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", installationManagedResourceName)
+	if err := a.deleteManagedResource(ctx, cr.Namespace, installationManagedResourceName, false); err != nil {
+		return fmt.Errorf("could not delete managed resource %q: %w", installationManagedResourceName, err)
 	}
 
 	// We can directly set `keepObjects=true` and delete the GVisor ManagedResource because all ContainerRuntimes are migrated

--- a/pkg/controller/actuator_migrate.go
+++ b/pkg/controller/actuator_migrate.go
@@ -6,13 +6,38 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/go-logr/logr"
 )
 
 // Migrate implements ContainerRuntime.Actuator.
-func (a *actuator) Migrate(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.ContainerRuntime, _ *extensionscontroller.Cluster) error {
+func (a *actuator) Migrate(ctx context.Context, log logr.Logger, cr *extensionsv1alpha1.ContainerRuntime, _ *extensionscontroller.Cluster) error {
+	managedResourceName := GVisorInstallationManagedResourceName + "-" + cr.Spec.WorkerPool.Name
+
+	log.Info("Setting keepObjects=true for managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", managedResourceName, "namespace", cr.Namespace, "containerRuntime", cr.Name)
+	if err := managedresources.SetKeepObjects(ctx, a.client, cr.Namespace, managedResourceName, true); err != nil {
+		return fmt.Errorf("could not keep objects of managed resource %q: %w", managedResourceName, err)
+	}
+
+	log.Info("Deleting managed resource due to the migration of the corresponding ContainerRuntime", "managedResourceName", managedResourceName, "namespace", cr.Namespace, "containerRuntime", cr.Name)
+	if err := a.deleteManagedResource(ctx, cr.Namespace, managedResourceName, false); err != nil {
+		return fmt.Errorf("could not delete managed resource %q: %w", managedResourceName, err)
+	}
+
+	// We can directly set `keepObjects=true` and delete the GVisor ManagedResource because all ContainerRuntimes are migrated
+	// during control plane migration. If the GVisor ManagedResource was already deleted no error is returned.
+	log.Info("Setting keepObjects=true as part of the migration operation", "managedResourceName", GVisorManagedResourceName)
+	if err := managedresources.SetKeepObjects(ctx, a.client, cr.Namespace, GVisorManagedResourceName, true); err != nil {
+		return fmt.Errorf("could not keep objects of managed resource %q: %w", GVisorManagedResourceName, err)
+	}
+	log.Info("Deleting managed resource as part of the migration operation", "managedResourceName", GVisorManagedResourceName)
+	if err := a.deleteManagedResource(ctx, cr.Namespace, GVisorManagedResourceName, false); err != nil {
+		return fmt.Errorf("could not delete managed resource %q: %w", GVisorManagedResourceName, err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the `keepObjects=true` on ManagedResources managed by this extensions when the corresponding ContainerRuntimes are migrated as part of control plane migration and then deletes them.

With this, the corresponding resources in the shoot will be kept and adopted by the ManagedResources that get deployed in the once the shoot's control plane once it is restored on the destination seed.

**Which issue(s) this PR fixes**:
Fixes #128 

**Special notes for your reviewer**:
Keeping the PR as a draft until I test it with the [getting started locally with extensions setup](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md)
Update: I successfully performed a control plane migration with the introduced changes

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
Fixed an issue where the migrate phase of control plane migration could become stuck. This was caused by ManagedResources associated with the `gvisor` extension not being properly handled deleted during the migration.
```
