### PR TITLE
Add vincinator as responsible

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,6 +34,8 @@ gardener-extension-runtime-gvisor:
                 username: 'MrBatschner'
               - type: 'githubUser'
                 username: 'Roncossek'
+              - type: 'githubUser'
+                username: 'Vincinator'
           gardener-extension-runtime-gvisor-installation:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/runtime-gvisor-installation
             dockerfile: 'Dockerfile'
@@ -45,6 +47,8 @@ gardener-extension-runtime-gvisor:
                 username: 'MrBatschner'
               - type: 'githubUser'
                 username: 'Roncossek'
+              - type: 'githubUser'
+                username: 'Vincinator'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os

**What this PR does / why we need it**:
Adds Vincinator as responsible for this repository in component-descriptor.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
