### PR TITLE
Remove `gardener/gardener-maintainers` from `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # gardener-extension-runtime-gvisor maintainers
-* @gardener/gardener-extension-runtime-gvisor-maintainers @gardener/gardener-maintainers
+* @gardener/gardener-extension-runtime-gvisor-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:
Github requests way too many reviews for gardener-maintainers. If a gardener-maintainer should really review a PR, please mention them manually.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator

```
