### PR TITLE
support gvisor for containerd2.1 with config version=3

### DIFF
--- a/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
@@ -54,6 +54,11 @@ data:
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
       runtime_type = "io.containerd.runsc.v1"
     EOF
+      elif grep -q '^version.*=.*3$' "$FILENAME"
+        cat <<EOF >> $FILENAME
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]
+      runtime_type = "io.containerd.runsc.v1"
+    EOF
       else
         cat <<EOF >> $FILENAME
     [plugins.cri.containerd.runtimes.runsc]
@@ -72,6 +77,16 @@ data:
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
       TypeUrl = "io.containerd.runsc.v1.options"
       ConfigPath = "/etc/containerd/runsc.toml"
+    EOF
+      RESTART_CONTAINERD=true
+    plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc
+    elif ! grep -q plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.runsc "$FILENAME"; then
+      cat <<EOF >> $FILENAME
+    [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc.options]
+      TypeUrl = "io.containerd.runsc.v1.options"
+      ConfigPath = "/etc/containerd/runsc.toml"
+      BinaryName = "/var/bin/containerruntimes/runsc"
+      ShimPath = "/var/bin/containerruntimes/containerd-shim-runsc-v1"
     EOF
       RESTART_CONTAINERD=true
     fi


### PR DESCRIPTION

**What this PR does / why we need it**:
gardener-extension-gvisor uses the install-gvisor-containerd.sh script inside a configmap-containerd.yaml to change the /etc/containerd/config.toml to make containerd aware of the gvisor installation (aka configure it).

Since Garden Linux 1877 uses containerd 2.1, and containerd 2.1 uses the format version=3 of the config file, some properties have changed.

This PR makes the required changes to also work with containerd 2.1 (aka config format version=3)

This commit changes the install-gvisor-containerd.sh in a way, that the new config properties are used so that gvisor can be used with containerd2.1 (i.e. with Garden Linux 1877)

In version=2 the property to define additional runtimes is called:
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]

In version=3 the property to define additional runtimes is called:
   [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Still in Progress. Manually changed config in local setup, and confirmed that the manual changes to `/etc/containerd/config.toml` work. Need the draft PR to test the changes in the install-gvisor-containerd.sh script provided by the configmap. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
Support containerd 2 with config version format=3
```
