### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -17,7 +17,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	shootVersion = "1.32.0"
+	shootVersion = "1.33.0"
 )
 
 var _ = Describe("Controller tests", func() {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	shootVersion = "1.28.0"
+	shootVersion = "1.32.0"
 )
 
 var _ = Describe("Controller tests", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
`runtime-gvisor` no longer supports Shoots with Кubernetes version <= 1.28.
```
