### PR TITLE
chore: update CI build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [Gardener Extension for the gVisor Container Runtime Sandbox](https://gardener.cloud)
 
 [![REUSE status](https://api.reuse.software/badge/github.com/gardener/gardener-extension-runtime-gvisor)](https://api.reuse.software/info/github.com/gardener/gardener-extension-runtime-gvisor)
-[![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/gardener-extension-runtime-gvisor-master/jobs/master-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-runtime-gvisor-master/jobs/master-head-update-job)
+[![Build status](https://github.com/gardener/gardener-extension-runtime-gvisor/actions/workflows/non-release.yaml/badge.svg?branch=master)](https://github.com/gardener/gardener-extension-runtime-gvisor/actions/workflows/non-release.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gardener/gardener-extension-runtime-gvisor)](https://goreportcard.com/report/github.com/gardener/gardener-extension-runtime-gvisor)
 
 Project Gardener implements the automated management and operation of [Kubernetes](https://kubernetes.io/) clusters as a service. Its main principle is to leverage Kubernetes concepts for all of its tasks.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the CI build status badge after the changeover from Concourse to GitHub Actions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
