### PR TITLE
Add set -o pipefail to react on make generate failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - name: run-verify
         run: |
-          set -eu
+          set -euo pipefail
           mkdir /tmp/blobs.d
           .ci/verify |& tee /tmp/blobs.d/verify-log.txt
           # verify calls `make sast-report`, which generates `gosec-report.sarif`


### PR DESCRIPTION

**What this PR does / why we need it**:
The build workflow reports success, even if make generate fails in the verify job.


**Special notes for your reviewer**:
port of: https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/pull/267

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
