### PR TITLE
ci: use dependabot to bump gh actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,3 +17,8 @@ updates:
   directory: /.test-defs
   schedule:
     interval: daily
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
With recent migration to https://gardener.github.io/cc-utils/github_actions.html we should also semi-automatically bump github actions such as `actions/setup-go@v5` (used in build.yaml workflow) regularly to reduce supply chain security risks

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
