### PR TITLE
ci: automatically bump GVISOR_VERSION file

### DIFF
--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -89,7 +89,7 @@ jobs:
           base_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
           title="chore: bump gVisor to ${ver}"
           body=""
-          body+="_Bump gVisor from \`${current}\`) to \`${ver}\`._\n"
+          body+="Bump gVisor from \`${current}\` to \`${ver}\`.\n"
           if [[ -n "${current}" ]]; then
             body+="\nDiff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
           fi

--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -1,0 +1,85 @@
+name: Update gVisor Version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *" # daily at 06:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-gvisor
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update GVISOR_VERSION and open/ensure PR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # 1) Find latest release-* tag upstream
+          latest_tag="$(git ls-remote --tags --refs https://github.com/google/gvisor.git \
+            | awk -F/ '/refs\/tags\/release-/{print $NF}' \
+            | sort -V | tail -n1)"
+          [[ -n "$latest_tag" ]] || { echo "No release-* tags found"; exit 1; }
+          ver="${latest_tag#release-}"
+
+          # 2) Read current version (if file exists)
+          current=""
+          [[ -f GVISOR_VERSION ]] && current="$(tr -d '\r\n' < GVISOR_VERSION || true)"
+
+          # 3) Skip if already up-to-date
+          if [[ "$ver" == "${current}" ]]; then
+            echo "GVISOR_VERSION already $ver — nothing to do."
+            exit 0
+          fi
+
+          branch="chore/update-gvisor-$ver"
+
+          # 4) Prepare branch, write file, commit, push
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git checkout -B "$branch"
+
+          printf '%s\n' "$ver" > GVISOR_VERSION
+          if git diff --quiet -- GVISOR_VERSION; then
+            echo "No file changes detected after write; exiting."
+            exit 0
+          fi
+
+          commit_msg=$'chore(gvisor): update to '"$ver"$'\n\n'
+          commit_msg+=$'Update GVISOR_VERSION from `'"${current}"'` to `'"${ver}"'`.\n'
+          commit_msg+=$'Upstream tag: '"${latest_tag}"$'\n'
+          [[ -n "$current" ]] && commit_msg+=$'Diff: https://github.com/google/gvisor/compare/release-'"${current}"'...'"${latest_tag}"$'\n'
+
+          git add GVISOR_VERSION
+          git commit -m "$commit_msg"
+          git push -u origin "$branch" --force-with-lease
+
+          # 5) If PR already open for this head branch, don't create another
+          owner='${{ github.repository_owner }}'
+          existing_url="$(gh pr list --state open --head "${owner}:${branch}" --json url --jq '.[0].url // empty')"
+          if [[ -n "$existing_url" ]]; then
+            echo "PR already open: $existing_url"
+            exit 0
+          fi
+
+          # 6) Create PR against default branch
+          base_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+          title="chore: bump gVisor to ${ver}"
+          body=$'_Update `GVISOR_VERSION` to `'"${ver}"'` (was `'"${current}"'`)._\n'
+          [[ -n "$current" ]] && body+=$'\nDiff: https://github.com/google/gvisor/compare/release-'"${current}"'...'"${latest_tag}"$'\n'
+          body+=$'\n**Release note**:\n```improvement operator\nUpdated gVisor binaries to `'"${ver}"'`.\n```'
+
+          gh pr create --base "$base_branch" --head "$branch" --title "$title" --body "$body"
+

--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -89,10 +89,7 @@ jobs:
           base_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
           title="chore: bump gVisor to ${ver}"
           body=""
-          body+="Bump gVisor from \`${current}\` to \`${ver}\`.\n"
-          if [[ -n "${current}" ]]; then
-            body+="\nDiff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
-          fi
+          body+="\nDiff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
           body+="\n**Release note**:\n\`\`\`improvement operator\nUpdated gVisor binaries to \`${ver}\`.\n\`\`\`\n"
 
           gh pr create --base "$base_branch" --head "$branch" --title "$title" --body "$(printf '%b' "$body")"

--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -27,26 +27,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          # 1) Find latest release-* tag upstream
+          # Find latest release-* tag upstream
           latest_tag="$(git ls-remote --tags --refs https://github.com/google/gvisor.git \
             | awk -F/ '/refs\/tags\/release-/{print $NF}' \
             | sort -V | tail -n1)"
           [[ -n "$latest_tag" ]] || { echo "No release-* tags found"; exit 1; }
           ver="${latest_tag#release-}"
 
-          # 2) Read current version (if file exists)
-          current=""
-          [[ -f GVISOR_VERSION ]] && current="$(tr -d '\r\n' < GVISOR_VERSION || true)"
+          # Read current version (file must exist)
+          if [[ ! -f GVISOR_VERSION ]]; then
+            echo "Error: GVISOR_VERSION file not found." >&2
+            exit 1
+          fi
+          current="$(tr -d '\r\n' < GVISOR_VERSION || true)"
 
-          # 3) Skip if already up-to-date
+          # Skip if already up-to-date
           if [[ "$ver" == "${current}" ]]; then
             echo "GVISOR_VERSION already $ver — nothing to do."
             exit 0
           fi
 
+          # Skip if branch already exists
           branch="chore/update-gvisor-$ver"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "branch already exists, please close related PR first or delete branch manually: $branch"
+            exit 0
+          fi
 
-          # 4) Prepare branch, write file, commit, push
+          # Prepare branch, write file, commit, push
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name  "github-actions[bot]"
           git checkout -B "$branch"
@@ -57,16 +65,19 @@ jobs:
             exit 0
           fi
 
-          commit_msg=$'chore(gvisor): update to '"$ver"$'\n\n'
-          commit_msg+=$'Update GVISOR_VERSION from `'"${current}"'` to `'"${ver}"'`.\n'
-          commit_msg+=$'Upstream tag: '"${latest_tag}"$'\n'
-          [[ -n "$current" ]] && commit_msg+=$'Diff: https://github.com/google/gvisor/compare/release-'"${current}"'...'"${latest_tag}"$'\n'
+          commit_msg=""
+          commit_msg+="chore(gvisor): update to ${ver}\n\n"
+          commit_msg+="Update GVISOR_VERSION from \`${current}\` to \`${ver}\`.\n"
+          commit_msg+="Upstream tag: ${latest_tag}\n"
+          if [[ -n "${current}" ]]; then
+            commit_msg+="Diff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
+          fi
 
           git add GVISOR_VERSION
-          git commit -m "$commit_msg"
+          git commit -m "$(printf '%b' "$commit_msg")"
           git push -u origin "$branch" --force-with-lease
 
-          # 5) If PR already open for this head branch, don't create another
+          # If PR already open for this head branch, don't create another
           owner='${{ github.repository_owner }}'
           existing_url="$(gh pr list --state open --head "${owner}:${branch}" --json url --jq '.[0].url // empty')"
           if [[ -n "$existing_url" ]]; then
@@ -74,12 +85,16 @@ jobs:
             exit 0
           fi
 
-          # 6) Create PR against default branch
+          # Create PR against default branch
           base_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
           title="chore: bump gVisor to ${ver}"
-          body=$'_Update `GVISOR_VERSION` to `'"${ver}"'` (was `'"${current}"'`)._\n'
-          [[ -n "$current" ]] && body+=$'\nDiff: https://github.com/google/gvisor/compare/release-'"${current}"'...'"${latest_tag}"$'\n'
-          body+=$'\n**Release note**:\n```improvement operator\nUpdated gVisor binaries to `'"${ver}"'`.\n```'
+          body=""
+          body+="_Update \`GVISOR_VERSION\` to \`${ver}\` (was \`${current}\`)._\n"
+          if [[ -n "${current}" ]]; then
+            body+="\nDiff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
+          fi
+          body+="\n**Release note**:\n\`\`\`improvement operator\nUpdated gVisor binaries to \`${ver}\`.\n\`\`\`\n"
 
-          gh pr create --base "$base_branch" --head "$branch" --title "$title" --body "$body"
+          gh pr create --base "$base_branch" --head "$branch" --title "$title" --body "$(printf '%b' "$body")"
+
 

--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -89,7 +89,7 @@ jobs:
           base_branch="$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
           title="chore: bump gVisor to ${ver}"
           body=""
-          body+="_Update \`GVISOR_VERSION\` to \`${ver}\` (was \`${current}\`)._\n"
+          body+="_Bump gVisor from \`${current}\`) to \`${ver}\`._\n"
           if [[ -n "${current}" ]]; then
             body+="\nDiff: https://github.com/google/gvisor/compare/release-${current}...${latest_tag}\n"
           fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a GH Action that checks if a new gvisor version exists at https://github.com/google/gvisor/tags and opens a PR to bump GVISOR_VERSION file.

**Special notes for your reviewer**:
Dependabot is unfortunately not an option technically.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
