### PR TITLE
fix: change build-target to correct one

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
             target: gardener-extension-runtime-gvisor
             oci-repository: gardener/extensions/runtime-gvisor
           - name: gardener-extension-runtime-gvisor-installation
-            target: gardener-extension-runtime-gvisor
+            target: gardener-extension-runtime-gvisor-installation
             oci-repository: gardener/extensions/runtime-gvisor-installation
     with:
       name: ${{ matrix.args.name }}


### PR DESCRIPTION
Fix regression from migration to GitHub-Actions where wrong build-target was configured.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator

```
