### PR TITLE
fix: use gh token in fetch version step from app

### DIFF
--- a/.github/workflows/bump-gvisor-version.yaml
+++ b/.github/workflows/bump-gvisor-version.yaml
@@ -34,6 +34,8 @@ jobs:
       - name: get latest GVISOR_VERSION
         shell: bash
         id: fetch_version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -66,7 +68,7 @@ jobs:
 
           body=""
           body+="\nDiff: https://github.com/google/gvisor/compare/release-${current_version}...${latest_tag}\n"
-          body+="\n**Release note**:\n\`\`\`improvement operator\nUpdated gVisor binaries to \`${upstream_version}\`.\n\`\`\`\n"
+          body+="\n**Release note**:\n\`\`\`improvement operator\nUpdated gVisor binaries to ${upstream_version}.\n\`\`\`\n"
           branch_name="bump-gvisor-to-$upstream_version"
           echo "commit-message=${commit_msg}" >> ${GITHUB_OUTPUT}
           echo "pr-body=${body}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
**What this PR does / why we need it**:
Missing GH_TOKEN in fetch_version step


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-runtime-gvisor/actions/runs/17369082701/job/49301075945#step:4:59

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
NONE
```
