### PR TITLE
ci: fix workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       id-token: write
       packages: write
+      pull-requests: write
     with:
       mode: release
 
@@ -28,6 +29,7 @@ jobs:
       contents: write
       id-token: write
       packages: write
+      pull-requests: write
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing permission label for release workflow. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See same fix in [provider-extension-azure ](https://github.com/gardener/gardener-extension-provider-azure/commit/913bf426c72b3228ad642db84d152805d1a7d60c)

Note that welease workflow is only triggered via workflow dispatch, which can only be triggered by users who can already write to the repo. Therefore no elevated permissions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
