### PR TITLE
Support containerd config file version 4

### DIFF
--- a/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
+++ b/charts/internal/gvisor-installation/templates/configmap-containerd.yaml
@@ -44,8 +44,9 @@ data:
     # configuring containerd config file for gVisor
     FILENAME=/var/host/etc/containerd/config.toml
 
-    # containerd config file has multiple versions, depending on containerd version a different config format is used 
+    # containerd config file has multiple versions, depending on containerd version a different config format is used
     # which in turn has different config property names
+    #    containerd2.3 uses version=4 by default
     #    containerd2.1 uses version=3 by default
     #    containerd1.7 uses version=2 by default
     #
@@ -59,8 +60,8 @@ data:
           PROPERTY_RUNSC_NAME='[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]'
           PROPERTY_RUNSC_OPTIONS_NAME='[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]'
           ;;
-        3)
-          echo "Containerd config version 3 detected."
+        3|4)
+          echo "Containerd config version $CONFIG_VERSION detected."
           PROPERTY_RUNSC_NAME='[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc]'
           PROPERTY_RUNSC_OPTIONS_NAME='[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runsc.options]'
           ;;


### PR DESCRIPTION
/area os
/kind enhancement

**What this PR does / why we need it**:

Adds support for containerd config file version 4 (introduced in containerd 2.3, LTS released 2026-04-30).

The install script that registers the `runsc` runtime in containerd's `config.toml` uses a `case` statement to determine the correct plugin paths based on the config file version. Currently it only handles versions 2 and 3 explicitly, with a fallback to version 1 format for any other value. When a node runs containerd 2.3, `containerd config default` outputs `version = 4`, which would hit the fallback and write the runsc entry with incorrect v1-style paths.

Config version 4 ([containerd/containerd#12562](https://github.com/containerd/containerd/pull/12562)) only moved server infrastructure fields (`[grpc]`, `[ttrpc]`, `[debug]`, `[metrics]`) into plugin blocks. The CRI runtime plugin paths (`io.containerd.cri.v1.runtime`) are unchanged from version 3.

This PR adds version 4 to the same case branch as version 3.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The [containerd support matrix](https://containerd.io/releases/) lists containerd 2.3 for Kubernetes 1.36+, but this reflects tested combinations, not hard incompatibility. Containerd 2.3 implements CRI v1 (same as 2.0/2.1/2.2), and Kubernetes 1.26+ uses CRI v1 exclusively. There is no protocol-level blocker.

**Release note**:
```feature operator
The gVisor runtime installation now supports containerd config file version 4 (containerd 2.3+), ensuring the `runsc` runtime is correctly registered on nodes running containerd 2.3.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended gVisor-containerd installation configuration to support containerd 2.3 alongside earlier versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gardener/gardener-extension-runtime-gvisor/pull/399)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->